### PR TITLE
Fixes the Formatters confusion

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "vscode": "^1.48.0"
   },
   "categories": [
-    "Formatters",
     "Visualization",
     "Themes",
     "Other"


### PR DESCRIPTION
This is confusing, as this extension doesn't do formatting?


![image](https://user-images.githubusercontent.com/5808377/148577035-6faf0fc8-b14b-4307-987c-b49f226e926a.png)


See #2